### PR TITLE
Add support for Gist URLs

### DIFF
--- a/git-identity-test.el
+++ b/git-identity-test.el
@@ -47,7 +47,9 @@
     (expect (git-identity--host-in-git-url "git@github.com:owner/repo.git")
             :to-equal "github.com")
     (expect (git-identity--host-in-git-url "github.com:owner/repo.git")
-            :to-equal "github.com")))
+            :to-equal "github.com")
+    (expect (git-identity--host-in-git-url "git@gist.github.com:1234123412341234.git")
+            :to-equal "gist.github.com")))
 
 (describe "git-identity--dir-in-git-url"
 

--- a/git-identity.el
+++ b/git-identity.el
@@ -215,9 +215,9 @@ identity setting."
                  (group (eval git-identity--host-pattern))
                  (?  ":" (+ (char digit)))
                  "/"))
-        (group (* (and (+ (eval git-identity--xalpha)) "/"))
-               (+ (eval git-identity--xalpha)))
-        "/"
+        (? (group (* (and (+ (eval git-identity--xalpha)) "/"))
+                  (+ (eval git-identity--xalpha)))
+           "/")
         (group (+ (eval git-identity--xalpha)))
         (?  ".git")
         (?  "/")

--- a/git-identity.el
+++ b/git-identity.el
@@ -336,16 +336,16 @@ E-mail: %s(git-identity--git-config-get \"user.email\")
    "Configure your identities"))
 
 ;;;###autoload (autoload 'git-identity-info "git-identity")
-(defalias 'git-identity-info #'git-identity-hydra/body
-  "Display the identity information of the current repository.")
+(defun git-identity-info ()
+  "Display the identity information of the current repository."
+  (interactive)
+  (git-identity--block-if-not-in-repo #'git-identity-hydra/body))
 
 (defun git-identity--block-if-not-in-repo (orig &rest args)
   "Prevent running ORIG function with ARGS if not in a Git repo."
   (if (git-identity--find-repo)
       (apply orig args)
     (user-error "Not inside a Git repo")))
-
-(advice-add #'git-identity-info :around #'git-identity--block-if-not-in-repo)
 
 ;;;; Mode definition
 ;;;###autoload

--- a/git-identity.el
+++ b/git-identity.el
@@ -151,7 +151,13 @@ identity setting."
                        (-map #'downcase it))))
     (cl-labels
         ((match-domain (domains)
-                       (-contains? domains domain))
+                       (-any-p (lambda (domain-pattern)
+                                 (when (stringp domain-pattern)
+                                   (string-match-p (rx-to-string `(and (or bos ".")
+                                                                       ,domain-pattern
+                                                                       eos))
+                                                   domain)))
+                               domains))
          (match-org (organizations)
                     (cl-intersection remote-dirs (-map #'downcase organizations)
                                      :test #'string-equal)))

--- a/git-identity.el
+++ b/git-identity.el
@@ -146,8 +146,9 @@ identity setting."
 (defun git-identity--guess-identity-by-url (url)
   "Pick an identity from `git-identity-list' based on URL."
   (let ((domain (git-identity--host-in-git-url url))
-        (remote-dirs (->> (split-string (git-identity--dir-in-git-url url) "/")
-                          (-map #'downcase))))
+        (remote-dirs (-some--> (git-identity--dir-in-git-url url)
+                       (split-string it "/")
+                       (-map #'downcase it))))
     (cl-labels
         ((match-domain (domains)
                        (-contains? domains domain))

--- a/git-identity.el
+++ b/git-identity.el
@@ -399,8 +399,7 @@ to this repository? "
 This mode enables the following features:
 
 - Add a hook to `magit-commit' to ensure that you have a
-  global/local identity configured in the repository.
-"
+  global/local identity configured in the repository."
   :global t
   (cond
    ;; Activate the mode


### PR DESCRIPTION
This PR adds support for Gist URLs. It will:

- Prevent errors when the repository URL has no directory.
- Match subdomains. If you have an identity for `github.com`, repository URLs in `gist.github.com` match the identity as well.